### PR TITLE
fix: adjust `ErrorWithCause` to match `ES2022` definition

### DIFF
--- a/.changeset/hungry-comics-promise.md
+++ b/.changeset/hungry-comics-promise.md
@@ -1,0 +1,11 @@
+---
+"iso-error": major
+---
+
+Adjust `ErrorWithCause` to match `ES2022` definition.
+
+standard type `ES2022` adds `cause?: unknown` to the `Error` type.
+
+It is not compatiable with the more restricted `cause?: Error`.
+
+So we need to adjust `ErrorWithCause` to match `ES2022` definition.

--- a/packages/google-cloud-api/package.json
+++ b/packages/google-cloud-api/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
-    "assertron": "^11.0.0",
+    "assertron": "^11.1.1",
     "cross-env": "^7.0.3",
     "depcheck": "^1.4.3",
     "eslint": "^8.27.0",

--- a/packages/iso-error-google-cloud-api/package.json
+++ b/packages/iso-error-google-cloud-api/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
-    "assertron": "^11.0.0",
+    "assertron": "^11.1.1",
     "cross-env": "^7.0.3",
     "depcheck": "^1.4.3",
     "eslint": "^8.27.0",

--- a/packages/iso-error/package.json
+++ b/packages/iso-error/package.json
@@ -54,7 +54,7 @@
     "@size-limit/preset-small-lib": "^8.1.0",
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
-    "assertron": "^11.0.0",
+    "assertron": "^11.1.1",
     "cross-env": "^7.0.3",
     "depcheck": "^1.4.3",
     "eslint": "^8.27.0",

--- a/packages/iso-error/ts/index.spec.ts
+++ b/packages/iso-error/ts/index.spec.ts
@@ -5,11 +5,11 @@ import { createError, MikuSickError, MyModuleError, SubError } from './testError
 
 describe('IsoError', () => {
   it('is an instance of Error', () => {
-    expect(new IsoError()).toBeInstanceOf(Error)
+    a.isInstanceof(new IsoError(), Error)
   })
   test('instanceof is working with restored prototype chain when transpiled to ES5', () => {
     // `jest` is using `ts-jest` with `tsconfig.json` which transpile to ES5
-    expect(new IsoError()).toBeInstanceOf(IsoError)
+    a.isInstanceof(new IsoError(), IsoError)
   })
   test('e.name is the name of the Error', () => {
     expect(new IsoError().name).toBe('IsoError')
@@ -315,13 +315,13 @@ describe('IsoError.deserialize()', () => {
     const e = new Error();
     (e as Record<string, any>).cause = new Error('sub')
     const actual = IsoError.deserialize(IsoError.serialize(e))
-    expect(actual.cause).toBeInstanceOf(Error)
+    a.isInstanceof(actual.cause, Error)
     expect(actual.cause?.message).toBe('sub')
   })
   test('restore cause', () => {
     const e = new IsoError('iso', { cause: new Error('a') })
     const actual = IsoError.deserialize(IsoError.serialize(e))
-    expect(actual.cause).toBeInstanceOf(Error)
+    a.isInstanceof(actual.cause, Error)
     expect(actual.cause?.message).toBe('a')
   })
   test('stack trace starts at call site', () => {
@@ -332,7 +332,7 @@ describe('IsoError.deserialize()', () => {
     const e = new Error();
     (e as Record<string, any>).cause = new SubError('sub')
     const actual = IsoError.deserialize(IsoError.serialize(e))
-    expect(actual.cause).toBeInstanceOf(Error)
+    a.isInstanceof(actual.cause, Error)
     expect(actual.cause?.name).toBe('SubError')
   })
 })
@@ -343,7 +343,7 @@ describe('serialization', () => {
 
     const actual = IsoError.parse(IsoError.stringify(e))
 
-    expect(actual).toBeInstanceOf(IsoError)
+    a.isInstanceof(actual, IsoError)
     expect(actual.name).toBe('IsoError')
     expect(actual.message).toBe('roundtrip')
   })
@@ -351,7 +351,8 @@ describe('serialization', () => {
   test('work with custom error, but only pass instanceof IsoError', () => {
     const e = new SubError('sub')
     const actual = IsoError.parse(IsoError.stringify(e))
-    expect(actual).toBeInstanceOf(IsoError)
+
+    a.isInstanceof(actual, IsoError)
     expect(actual.name).toBe('SubError')
     expect(actual.message).toBe('sub')
   })
@@ -398,7 +399,7 @@ describe('serialization', () => {
       const e = new AggregateError([new Error('a'), new Error('b')], 'abc')
       const actual = IsoError.deserialize(IsoError.serialize(e))
 
-      expect(actual).toBeInstanceOf(AggregateError)
+      a.isInstanceof(actual, AggregateError)
     })
   }
 })
@@ -415,7 +416,7 @@ describe('IsoError.fromSerializable()', () => {
   test('convert serializable json object back to an error', () => {
     const actual = IsoError.fromSerializable({ name: 'IsoError', message: 'some message' })
 
-    expect(actual).toBeInstanceOf(IsoError)
+    a.isInstanceof(actual, IsoError)
     expect(actual.message).toEqual('some message')
   })
 })

--- a/packages/iso-error/ts/index.ts
+++ b/packages/iso-error/ts/index.ts
@@ -279,7 +279,7 @@ export namespace IsoError {
     ssf?: (...args: any) => any
   }
 
-  export type ErrorWithCause = Error & Options
+  export type ErrorWithCause = Error & { cause?: unknown }
 }
 
 /**

--- a/packages/iso-error/tsconfig.base.json
+++ b/packages/iso-error/tsconfig.base.json
@@ -18,9 +18,7 @@
     "useDefineForClassFields": true
   },
   "include": [
+    "ts",
     "types"
-  ],
-  "files": [
-    "ts/index.ts"
   ]
 }

--- a/packages/iso-error/tsconfig.json
+++ b/packages/iso-error/tsconfig.json
@@ -2,9 +2,5 @@
   "extends": "./tsconfig.esm.json",
   "compilerOptions": {
     "noEmit": true
-  },
-  "include": [
-    "ts",
-    "typings"
-  ]
+  }
 }

--- a/packages/iso-error/tsconfig.lint.json
+++ b/packages/iso-error/tsconfig.lint.json
@@ -2,9 +2,5 @@
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
     "noEmit": true
-  },
-  "include": [
-    "ts",
-    "typings"
-  ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
       '@commitlint/cli': 17.4.1
       '@commitlint/config-conventional': 17.4.0
       eslint: 8.27.0
-      eslint-plugin-harmony: 7.1.0_4x4gl2nsnl44fkojrxigz5trtq
+      eslint-plugin-harmony: 7.1.0_3qguc2nxipgl7dwjxvk7f4jowq
       husky: 8.0.2
       jest: 29.3.1_odkjkoia5xunhxkdrka32ib6vi
       jest-progress-tracker: 3.0.4_jest@29.3.1
@@ -50,7 +50,7 @@ importers:
       '@types/jest': ^29.2.3
       '@types/node': ^18.11.9
       '@typescript-eslint/eslint-plugin': ^5.43.0
-      assertron: ^11.0.0
+      assertron: ^11.1.1
       cross-env: ^7.0.3
       depcheck: ^1.4.3
       eslint: ^8.27.0
@@ -73,17 +73,17 @@ importers:
       iso-error: link:../iso-error
       type-plus: 5.0.0
     devDependencies:
-      '@apidevtools/swagger-cli': 4.0.4_openapi-types@12.0.2
+      '@apidevtools/swagger-cli': 4.0.4_openapi-types@12.1.0
       '@size-limit/file': 8.1.0_size-limit@8.1.0
       '@size-limit/webpack': 8.1.0_size-limit@8.1.0
       '@types/jest': 29.2.3
       '@types/node': 18.11.9
-      '@typescript-eslint/eslint-plugin': 5.43.0_wze2rj5tow7zwqpgbdx2buoy3m
-      assertron: 11.0.1
+      '@typescript-eslint/eslint-plugin': 5.43.0_askvm7f76gpzkbutwx5tt5yocu
+      assertron: 11.1.1
       cross-env: 7.0.3
       depcheck: 1.4.3
       eslint: 8.27.0
-      eslint-plugin-harmony: 7.1.0_4x4gl2nsnl44fkojrxigz5trtq
+      eslint-plugin-harmony: 7.1.0_rzirydrqnzrv3gyj3tz66lmvju
       jest: 29.3.1_@types+node@18.11.9
       jest-validate: 29.3.1
       jest-watch-suspend: 1.1.2_jest@29.3.1
@@ -102,7 +102,7 @@ importers:
       '@size-limit/preset-small-lib': ^8.1.0
       '@types/jest': ^29.2.3
       '@types/node': ^18.11.9
-      assertron: ^11.0.0
+      assertron: ^11.1.1
       cross-env: ^7.0.3
       depcheck: ^1.4.3
       eslint: ^8.27.0
@@ -125,11 +125,11 @@ importers:
       '@size-limit/preset-small-lib': 8.1.0_size-limit@8.1.0
       '@types/jest': 29.2.3
       '@types/node': 18.11.9
-      assertron: 11.0.1
+      assertron: 11.1.1
       cross-env: 7.0.3
       depcheck: 1.4.3
       eslint: 8.27.0
-      eslint-plugin-harmony: 7.1.0_4x4gl2nsnl44fkojrxigz5trtq
+      eslint-plugin-harmony: 7.1.0_3qguc2nxipgl7dwjxvk7f4jowq
       jest: 29.3.1_@types+node@18.11.9
       jest-environment-jsdom: 29.3.1
       jest-validate: 29.3.1
@@ -140,7 +140,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      ts-jest: 29.0.3_6crhf7ajeizammv76u753sn6i4
+      ts-jest: 29.0.3_yrzvrtyqhk5uupbsgu4zsul7ki
       tslib: 2.4.1
       type-plus: 5.0.0
       typescript: 4.9.3
@@ -152,7 +152,7 @@ importers:
       '@types/jest': ^29.2.3
       '@types/node': ^18.11.9
       '@typescript-eslint/eslint-plugin': ^5.43.0
-      assertron: ^11.0.0
+      assertron: ^11.1.1
       cross-env: ^7.0.3
       depcheck: ^1.4.3
       eslint: ^8.27.0
@@ -177,12 +177,12 @@ importers:
       '@size-limit/webpack': 8.1.0_size-limit@8.1.0
       '@types/jest': 29.2.3
       '@types/node': 18.11.9
-      '@typescript-eslint/eslint-plugin': 5.43.0_wze2rj5tow7zwqpgbdx2buoy3m
-      assertron: 11.0.1
+      '@typescript-eslint/eslint-plugin': 5.43.0_askvm7f76gpzkbutwx5tt5yocu
+      assertron: 11.1.1
       cross-env: 7.0.3
       depcheck: 1.4.3
       eslint: 8.27.0
-      eslint-plugin-harmony: 7.1.0_4x4gl2nsnl44fkojrxigz5trtq
+      eslint-plugin-harmony: 7.1.0_rzirydrqnzrv3gyj3tz66lmvju
       iso-error: link:../iso-error
       jest: 29.3.1_@types+node@18.11.9
       jest-validate: 29.3.1
@@ -193,7 +193,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      ts-jest: 29.0.3_6crhf7ajeizammv76u753sn6i4
+      ts-jest: 29.0.3_yrzvrtyqhk5uupbsgu4zsul7ki
       typescript: 4.9.3
 
   packages/iso-error-web:
@@ -227,11 +227,11 @@ importers:
       '@size-limit/webpack': 8.1.0_size-limit@8.1.0
       '@types/jest': 29.2.3
       '@types/node': 18.11.9
-      '@typescript-eslint/eslint-plugin': 5.43.0_wze2rj5tow7zwqpgbdx2buoy3m
+      '@typescript-eslint/eslint-plugin': 5.43.0_askvm7f76gpzkbutwx5tt5yocu
       cross-env: 7.0.3
       depcheck: 1.4.3
       eslint: 8.27.0
-      eslint-plugin-harmony: 7.1.0_4x4gl2nsnl44fkojrxigz5trtq
+      eslint-plugin-harmony: 7.1.0_rzirydrqnzrv3gyj3tz66lmvju
       jest: 29.3.1_@types+node@18.11.9
       jest-validate: 29.3.1
       jest-watch-suspend: 1.1.2_jest@29.3.1
@@ -241,7 +241,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      ts-jest: 29.0.3_6crhf7ajeizammv76u753sn6i4
+      ts-jest: 29.0.3_yrzvrtyqhk5uupbsgu4zsul7ki
       type-plus: 5.0.0
       typescript: 4.9.3
 
@@ -268,12 +268,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /@apidevtools/swagger-cli/4.0.4_openapi-types@12.0.2:
+  /@apidevtools/swagger-cli/4.0.4_openapi-types@12.1.0:
     resolution: {integrity: sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@apidevtools/swagger-parser': 10.1.0_openapi-types@12.0.2
+      '@apidevtools/swagger-parser': 10.1.0_openapi-types@12.1.0
       chalk: 4.1.2
       js-yaml: 3.14.1
       yargs: 15.4.1
@@ -285,7 +285,7 @@ packages:
     resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
     dev: true
 
-  /@apidevtools/swagger-parser/10.1.0_openapi-types@12.0.2:
+  /@apidevtools/swagger-parser/10.1.0_openapi-types@12.1.0:
     resolution: {integrity: sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==}
     peerDependencies:
       openapi-types: '>=7'
@@ -297,7 +297,7 @@ packages:
       ajv: 8.11.2
       ajv-draft-04: 1.0.0_ajv@8.11.2
       call-me-maybe: 1.0.2
-      openapi-types: 12.0.2
+      openapi-types: 12.1.0
     dev: true
 
   /@babel/code-frame/7.18.6:
@@ -310,6 +310,34 @@ packages:
   /@babel/compat-data/7.20.1:
     resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/compat-data/7.20.10:
+    resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core/7.20.12:
+    resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.7
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.7
+      '@babel/parser': 7.20.7
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.20.7
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/core/7.20.2:
@@ -344,6 +372,15 @@ packages:
       jsesc: 2.5.2
     dev: true
 
+  /@babel/generator/7.20.7:
+    resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.7
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
   /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
     engines: {node: '>=6.9.0'}
@@ -354,6 +391,20 @@ packages:
       '@babel/core': 7.20.2
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
+      semver: 6.3.0
+    dev: true
+
+  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.20.10
+      '@babel/core': 7.20.12
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.4
+      lru-cache: 5.1.1
       semver: 6.3.0
     dev: true
 
@@ -382,6 +433,22 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.2
+    dev: true
+
+  /@babel/helper-module-transforms/7.20.11:
+    resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/helper-module-transforms/7.20.2:
@@ -445,6 +512,17 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers/7.20.7:
+    resolution: {integrity: sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
@@ -468,6 +546,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.2
+    dev: true
+
+  /@babel/parser/7.20.7:
+    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.2:
@@ -615,6 +701,15 @@ packages:
       '@babel/types': 7.20.2
     dev: true
 
+  /@babel/template/7.20.7:
+    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.20.7
+      '@babel/types': 7.20.7
+    dev: true
+
   /@babel/traverse/7.20.1:
     resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
     engines: {node: '>=6.9.0'}
@@ -633,8 +728,35 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse/7.20.12:
+    resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.7
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.20.7
+      '@babel/types': 7.20.7
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types/7.20.2:
     resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types/7.20.7:
+    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -1875,7 +1997,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.43.0_wze2rj5tow7zwqpgbdx2buoy3m:
+  /@typescript-eslint/eslint-plugin/5.43.0_askvm7f76gpzkbutwx5tt5yocu:
     resolution: {integrity: sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1886,13 +2008,40 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
+      '@typescript-eslint/parser': 5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/type-utils': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
       '@typescript-eslint/utils': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
       debug: 4.3.4
       eslint: 8.27.0
       ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.48.1_askvm7f76gpzkbutwx5tt5yocu:
+    resolution: {integrity: sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y
+      '@typescript-eslint/scope-manager': 5.48.1
+      '@typescript-eslint/type-utils': 5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y
+      '@typescript-eslint/utils': 5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y
+      debug: 4.3.4
+      eslint: 8.27.0
+      ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
@@ -1935,12 +2084,40 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y:
+    resolution: {integrity: sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.48.1
+      '@typescript-eslint/types': 5.48.1
+      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.9.3
+      debug: 4.3.4
+      eslint: 8.27.0
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager/5.43.0:
     resolution: {integrity: sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.43.0
       '@typescript-eslint/visitor-keys': 5.43.0
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.48.1:
+    resolution: {integrity: sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.48.1
+      '@typescript-eslint/visitor-keys': 5.48.1
     dev: true
 
   /@typescript-eslint/type-utils/5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y:
@@ -1963,8 +2140,33 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y:
+    resolution: {integrity: sha512-Hyr8HU8Alcuva1ppmqSYtM/Gp0q4JOp1F+/JH5D1IZm/bUBrV0edoewQZiEc1r6I8L4JL21broddxK8HAcZiqQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.9.3
+      '@typescript-eslint/utils': 5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y
+      debug: 4.3.4
+      eslint: 8.27.0
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types/5.43.0:
     resolution: {integrity: sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.48.1:
+    resolution: {integrity: sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -1979,6 +2181,27 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.43.0
       '@typescript-eslint/visitor-keys': 5.43.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.48.1_typescript@4.9.3:
+    resolution: {integrity: sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.48.1
+      '@typescript-eslint/visitor-keys': 5.48.1
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -2009,11 +2232,39 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.48.1_e3uo4sehh4zr4i6m57mkkxxv7y:
+    resolution: {integrity: sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.48.1
+      '@typescript-eslint/types': 5.48.1
+      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.9.3
+      eslint: 8.27.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.27.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.43.0:
     resolution: {integrity: sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.43.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.48.1:
+    resolution: {integrity: sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.48.1
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -2454,16 +2705,16 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /assertron/11.0.1:
-    resolution: {integrity: sha512-D1U7weslbYgIoItGhuRqasdvZtU/1dtO9cmeMhuUbcNzd6Zztp3mlNlUF/EtZBfgjSFLjgUhBxw5uabsDR/b8A==}
+  /assertron/11.1.1:
+    resolution: {integrity: sha512-COdaURJ626RH/tBOnC6sKtJexlgKYa6SNIODggpfAc9/Y295c6W4XM0y96zICJsgsQLzybIgCzZX3ntaSZAs2Q==}
     engines: {node: '>= 10'}
     dependencies:
       is-promise: 4.0.0
-      iso-error: 4.4.0
-      path-equal: 1.2.4
+      iso-error: 5.0.2
+      path-equal: 1.2.5
       satisfier: 5.4.2
-      tersify: 3.10.5
-      type-plus: 4.17.0
+      tersify: 3.11.1
+      type-plus: 5.1.0
     dev: true
 
   /assign-symbols/1.0.0:
@@ -3806,8 +4057,8 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.27.0:
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+  /eslint-config-prettier/8.6.0_eslint@8.27.0:
+    resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -3815,18 +4066,35 @@ packages:
       eslint: 8.27.0
     dev: true
 
-  /eslint-plugin-harmony/7.1.0_4x4gl2nsnl44fkojrxigz5trtq:
+  /eslint-plugin-harmony/7.1.0_3qguc2nxipgl7dwjxvk7f4jowq:
     resolution: {integrity: sha512-+uJpoXXKbLqvadllSqyouKHgpNnYnIJmn0syQm/nQv7BG3QkjTavLWG2DNmV6Y8c544VkCIB3YWF2M59YPn/1g==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.0.0
       eslint: '>=8.4.0'
       eslint-config-prettier: ^8.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.43.0_wze2rj5tow7zwqpgbdx2buoy3m
+      '@typescript-eslint/eslint-plugin': 5.48.1_askvm7f76gpzkbutwx5tt5yocu
       '@typescript-eslint/experimental-utils': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
       '@typescript-eslint/parser': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
       eslint: 8.27.0
-      eslint-config-prettier: 8.5.0_eslint@8.27.0
+      eslint-config-prettier: 8.6.0_eslint@8.27.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-harmony/7.1.0_rzirydrqnzrv3gyj3tz66lmvju:
+    resolution: {integrity: sha512-+uJpoXXKbLqvadllSqyouKHgpNnYnIJmn0syQm/nQv7BG3QkjTavLWG2DNmV6Y8c544VkCIB3YWF2M59YPn/1g==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: '>=8.4.0'
+      eslint-config-prettier: ^8.0.0
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.43.0_askvm7f76gpzkbutwx5tt5yocu
+      '@typescript-eslint/experimental-utils': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
+      '@typescript-eslint/parser': 5.43.0_e3uo4sehh4zr4i6m57mkkxxv7y
+      eslint: 8.27.0
+      eslint-config-prettier: 8.6.0_eslint@8.27.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4631,6 +4899,11 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+    dev: true
+
   /immutable/4.1.0:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
     dev: true
@@ -5006,8 +5279,8 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /iso-error/4.4.0:
-    resolution: {integrity: sha512-DRPiLihxUYhz4rMbfdzvm+l8ihd+d1QXClNa/SJk5HMrX93T5y7A7S+rwNOS+x2Tlzfc/IE0OrJhz/RyQ6s28Q==}
+  /iso-error/5.0.2:
+    resolution: {integrity: sha512-Yf9e0ROw4TpMHU92s2YeV0G05cOk5/HkQiRZxYAUqfI9ls5wLIPI+5plTLOrFJIPeohMOVNdFZqiUiB55QHIqA==}
     engines: {node: '>= 10'}
     dev: true
 
@@ -5627,7 +5900,7 @@ packages:
       jest: '>=23'
     dependencies:
       chalk: 2.4.2
-      jest: 29.3.1_odkjkoia5xunhxkdrka32ib6vi
+      jest: 29.3.1_@types+node@18.11.9
       unpartial: 0.6.4
     dev: true
 
@@ -5639,7 +5912,7 @@ packages:
       jest-validate: '>= 23.4.0'
     dependencies:
       chalk: 4.1.2
-      jest: 29.3.1_odkjkoia5xunhxkdrka32ib6vi
+      jest: 29.3.1_@types+node@18.11.9
       jest-validate: 29.3.1
     dev: true
 
@@ -5651,7 +5924,7 @@ packages:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 4.1.2
-      jest: 29.3.1_odkjkoia5xunhxkdrka32ib6vi
+      jest: 29.3.1_@types+node@18.11.9
       jest-regex-util: 29.2.0
       jest-watcher: 29.3.1
       slash: 5.0.0
@@ -5875,6 +6148,12 @@ packages:
     hasBin: true
     dev: true
 
+  /json5/2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
+
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
@@ -6079,6 +6358,12 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
+    dev: true
+
+  /lru-cache/5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
     dev: true
 
   /lru-cache/6.0.0:
@@ -6769,8 +7054,8 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /openapi-types/12.0.2:
-    resolution: {integrity: sha512-GuTo7FyZjOIWVhIhQSWJVaws6A82sWIGyQogxxYBYKZ0NBdyP2CYSIgOwFfSB+UVoPExk/YzFpyYitHS8KVZtA==}
+  /openapi-types/12.1.0:
+    resolution: {integrity: sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==}
     dev: true
 
   /optionator/0.8.3:
@@ -6942,8 +7227,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /path-equal/1.2.4:
-    resolution: {integrity: sha512-qYtLj9MtoSedTVGfJ1VesEKnO3378nofKJUSTKDZY658T3eXHGPCPnFQiH4bFyHg0TIRBI5qJb6MKjbv2LAmsQ==}
+  /path-equal/1.2.5:
+    resolution: {integrity: sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==}
     dev: true
 
   /path-exists/4.0.0:
@@ -8239,6 +8524,40 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /ts-jest/29.0.3_yrzvrtyqhk5uupbsgu4zsul7ki:
+    resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.3.1_@types+node@18.11.9
+      jest-util: 29.3.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.8
+      typescript: 4.9.3
+      yargs-parser: 21.1.1
+    dev: true
+
   /ts-node/10.9.1_wup25etrarvlqkprac7h35hj7u:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -8427,18 +8746,18 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /type-plus/4.17.0:
-    resolution: {integrity: sha512-1KiW6kqhaqHSRou4OIiPl0YocrgA/5evOSj+sHUZ20FyjVuSs/eKEtdOALKd4UD4LBviWW38SRWGeYJzX5+zMA==}
-    dependencies:
-      tersify: 3.11.1
-      unpartial: 1.0.4
-    dev: true
-
   /type-plus/5.0.0:
     resolution: {integrity: sha512-nKp5pOQDldmR9BdEjLplLFwiXTVhOK2kReBSgVJ65URDLXCqENYzVDCONaExADIIc1CAGzvzTkB0TUgMAWR2qQ==}
     dependencies:
       tersify: 3.11.1
       unpartial: 1.0.4
+
+  /type-plus/5.1.0:
+    resolution: {integrity: sha512-1+meU/urZTVvH0bvMgQkGtkVU6qUTkXSH36CTeRXjhzlOYKVW8/i5AuG0divp3LE6d3iUODBPzraLDrL2iB91Q==}
+    dependencies:
+      tersify: 3.11.1
+      unpartial: 1.0.4
+    dev: true
 
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -8874,6 +9193,10 @@ packages:
 
   /yallist/2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
+    dev: true
+
+  /yallist/3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
 
   /yallist/4.0.0:


### PR DESCRIPTION
standard type `ES2022` adds `cause?: unknown` to the `Error` type.

It is not compatiable with the more restricted `cause?: Error`.

So we need to adjust `ErrorWithCause` to match `ES2022` definition.